### PR TITLE
Fix bidi selection

### DIFF
--- a/src/layer/marker.js
+++ b/src/layer/marker.js
@@ -193,7 +193,7 @@ var Marker = function(parentEl) {
             this.elt(
                 clazz,
                 "height:" + height + "px;" +
-                "width:" + selection.width + (extraLength || 0) + "px;" +
+                "width:" + (selection.width + (extraLength || 0)) + "px;" +
                 "top:" + top + "px;" +
                 "left:" + (padding + selection.left) + "px;" + (extraStyle || "")
             );


### PR DESCRIPTION
Currently, when you select characters in a bidi line, it selects 10x more width than required. It is because of the contatinating a 0 to a string. This pull request fixes this problem.